### PR TITLE
Automatic loading of credentials from environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,157 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+### JetBrains.gitignore template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = ">=2.0.0"
+spotify-token = ">=0.1.0"
+bs4 = ">=0.0.1"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,87 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b2cd37f966b70260564adf88caa8de0f60a581461f9c205d72b2c26a6093b4a5"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:034740f6cb549b4e932ae1ab975581e6103ac8f942200a0e9759065984391858",
+                "sha256:945065979fb8529dd2f37dbb58f00b661bdbcbebf954f93b32fdf5263ef35348",
+                "sha256:ba6d5c59906a85ac23dadfe5c88deaf3e179ef565f4898671253e50a78680718"
+            ],
+            "version": "==4.7.1"
+        },
+        "bs4": {
+            "hashes": [
+                "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"
+            ],
+            "index": "pypi",
+            "version": "==0.0.1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:afa56bf14907bb09403e5d15fbed6275caa4174d36b975226e3b67a3bb6e2c4b",
+                "sha256:eaed742b48b1f3e2d45ba6f79401b2ed5dc33b2123dfe216adb90d4bfa0ade26"
+            ],
+            "version": "==1.8"
+        },
+        "spotify-token": {
+            "hashes": [
+                "sha256:8230c0ca3dc6ef3d7d3520ef5804870bcf4f13e05c2d733e98ff3f823e92e10c",
+                "sha256:f7ee53dbf572dd34b598de94a3b755d67e83a95608eb9e7fed692c778596c5fc"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ If you prefer to log in without explicitly passing your credentials, you can set
 two environment variables, `SPOTIFY_USERNAME` and `SPOTIFY_PASSWORD`. The script
 first check for the existence of those environment variables, only asking for your
 credentials via the console if they are not found. 
+
+Command Line Arguments
+----------------------
+
+Run script with `--log DEBUG`, `--log INFO`, `--log ERROR` to set the logging level. 
+Or leave that argument off entirely and only see logs if errors occur. 
  
 Credit to richstokes for streamlining the API interaction and JSON parsing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ Installing requirments
 pip install -r requirements.txt
 ```
 
- Aside from that, it can be cloned and run as is. 
+Aside from that, it can be cloned and run as is. 
+ 
+Logging in with environment variables
+-------------------------------------
+
+If you prefer to log in without explicitly passing your credentials, you can set 
+two environment variables, `SPOTIFY_USERNAME` and `SPOTIFY_PASSWORD`. The script
+first check for the existence of those environment variables, only asking for your
+credentials via the console if they are not found. 
  
 Credit to richstokes for streamlining the API interaction and JSON parsing
 

--- a/__main__.py
+++ b/__main__.py
@@ -5,8 +5,10 @@ from bs4 import BeautifulSoup
 import json
 import time
 import spotify_token as st
-import ast
 from datetime import datetime
+from collections import namedtuple
+
+Credentials = namedtuple('Credentials', 'username, password')
 
 
 class Spotify:
@@ -65,9 +67,27 @@ class Spotify:
         print(f"{self.lyrics}\n")
 
 
+def get_credentials():
+    """
+    Return namedtuple containing 'username' and 'password' values. Try loading from the environment first, if unable,
+    enter credentials to the input.
+
+    :return: namedtuple(username, password)
+    :rtype: namedtuple
+    """
+    username = os.getenv('SPOTIFY_USERNAME')
+    password = os.getenv('SPOTIFY_PASSWORD')
+    if not (username and password):
+        username = input('Spotify username: ')
+        password = input('Spotify password: ')
+
+    return Credentials(username, password)
+
+
 def main():
-    user = input('Spotify username: ')
-    passw = input('Spotify password: ')
+    credentials = get_credentials()
+    user = credentials.username
+    passw = credentials.password
     spt = Spotify(user, passw)
     while True:
         try:
@@ -79,4 +99,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/__main__.py
+++ b/__main__.py
@@ -7,6 +7,25 @@ import time
 import spotify_token as st
 from datetime import datetime
 from collections import namedtuple
+import logging
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--log', help='set the log level', choices=['INFO', 'DEBUG', 'ERROR'], default='ERROR')
+args = parser.parse_args()
+
+logger = logging.getLogger(__name__)
+
+formatter = logging.Formatter(fmt='{asctime} - {levelname} - {message}', style='{')
+
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)
+
+log_level = getattr(logging, args.log)
+logger.setLevel(log_level)
+
+print(f'Starting with log level: {logger.level}')
 
 Credentials = namedtuple('Credentials', 'username, password')
 
@@ -37,16 +56,28 @@ class Spotify:
         self.lyrics = ''
 
     def gettoken(self):
+        logger.info('getting token')
         if self.token is None or self.token_exp < datetime.now():
+            logger.info('no token found, starting new session')
             data = st.start_session(self.user, self.passw)
             self.token = data[0]
             self.token_exp = data[1]
+            logger.info('token acquired')
+        else:
+            logger.info(f'using cached token')
 
     def getsong(self):
+        logger.debug('calling `getsong`')
         response = requests.get('https://api.spotify.com/v1/me/player/currently-playing', headers=self.spotheaders)
-        if response.status_code != 200:
-            print(response.status_code)
-            print("Bad Response from Spotify API")
+        logger.debug(f'status code: {response.status_code}')
+        try:
+            if response.status_code == 204:
+                logger.info('No song playing')
+            if not response.json():
+                logger.debug('no json payload')
+                return
+        except requests.exceptions.HTTPError as e:
+            raise e
         else:
             json_data = json.loads(response.text)
             self.artist = json_data["item"]["artists"][0]["name"]
@@ -56,10 +87,13 @@ class Spotify:
                 self.getlyrics()
 
     def getlyrics(self):
+        logger.debug('calling `getlyrics`')
         self.lyrics = ''
         s = requests.Session()
         url = 'https://www.google.com/search?q={}&ie=utf-8&oe=utf-8'.format(self.query)
+        logger.debug(f'url -> {url}')
         r = s.get(url, headers=self.lyricheaders)
+        logger.debug('response received... parsing')
         soup = BeautifulSoup(r.text, "html.parser").find_all("span", {"jsname": "YS01Ge"})
         for link in soup:
             self.lyrics += (link.text + '\n')
@@ -95,6 +129,8 @@ def main():
             time.sleep(3)
         except KeyboardInterrupt:
             quit()
+        except Exception:
+            logger.exception('Error occured', exc_info=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding a `get_credentials` function that checks for the existence of two environment variables to get the login credentials. If they don't exist, it'll call the console input as before. This way in your .bash_rc or .bash_profile you can export your credentials and it will log in without any console input. I use a password manager, so re-entering a long string of random chars is just not gonna happen. Also added Pipfile and Pipfile.lock, if you're into that sorta thing. Doesn't affect the requrements.txt install, but adds easier pinning of dependencies. 

```
# .bash_profile

SPOTIFY_USERNAME=xxxEmoBoy6669xxx@hotmail.com
SPOTIFY_PASSWORD=i_think_thrice_is_heavy
```

Call the script like you usually would.

![gif](https://user-images.githubusercontent.com/19809789/54870229-08c52f00-4d7a-11e9-97f0-bc0b0765c730.gif)
