### PR TITLE
Updated README.md for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ two environment variables, `SPOTIFY_USERNAME` and `SPOTIFY_PASSWORD`. The script
 first check for the existence of those environment variables, only asking for your
 credentials via the console if they are not found. 
 
+```
+# ~/.bash_profile
+...
+SPOTIFY_USERNAME=your_username
+SPOTIFY_PASSWORD=your_password
+export SPOTIFY_USERNAME
+export SPOTIFY_PASSWORD
+...
+```
+
+
 Command Line Arguments
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ credentials via the console if they are not found.
 ```
 # ~/.bash_profile
 ...
-SPOTIFY_USERNAME=your_username
-SPOTIFY_PASSWORD=your_password
-export SPOTIFY_USERNAME
-export SPOTIFY_PASSWORD
+export SPOTIFY_USERNAME=your_username
+export SPOTIFY_PASSWORD=your_password
 ...
 ```
 


### PR DESCRIPTION
Just stating the usage of the environment variables is probably not very helpful to some users. Added a snippet of a sample ./bash_profile that clarifies the need to `export` the variables